### PR TITLE
Add support for the Citrea light client oracle

### DIFF
--- a/src/oracles/CitreaOracle.sol
+++ b/src/oracles/CitreaOracle.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.8.26;
 
 import { BitcoinOracle } from "./BitcoinOracle.sol";
 
-import { ICitrea } from "./interfaces/ICitrea.sol";
+interface ICitrea {
+    function blockNumber() external view returns (uint256);
+    function blockHashes(uint256) external view returns (bytes32);
+}
 
 /**
  * @dev Bitcoin oracle using the Citrea ABI.

--- a/src/oracles/interfaces/ICitrea.sol
+++ b/src/oracles/interfaces/ICitrea.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-interface ICitrea {
-    function blockNumber() external view returns (uint256);
-    function blockHashes(uint256) external view returns (bytes32);
-}


### PR DESCRIPTION
This PR makes the Bitcoin Oracle more flexible and allows overriding the light client calling functions. This allows us to more easily integrate various Bitcoin L2s.