### PR TITLE
fix: 'Discount' logic

### DIFF
--- a/src/settlers/BaseSettler.sol
+++ b/src/settlers/BaseSettler.sol
@@ -125,7 +125,7 @@ abstract contract BaseSettler is EIP712 {
         uint256 expiryTimestamp,
         address newDestination,
         bytes calldata call,
-        uint48 discount,
+        uint64 discount,
         uint32 timeToBuy,
         bytes calldata solverSignature
     ) internal {
@@ -157,7 +157,7 @@ abstract contract BaseSettler is EIP712 {
             uint256[2] calldata input = inputs[i];
             uint256 tokenId = input[0];
             uint256 allocatedAmount = input[1];
-            uint256 amountAfterDiscount = allocatedAmount * discount / DISCOUNT_DENOM;
+            uint256 amountAfterDiscount = allocatedAmount * (DISCOUNT_DENOM - discount) / DISCOUNT_DENOM;   // If discount > DISCOUNT_DENOM the subtraction will throw an exception
             SafeTransferLib.safeTransferFrom(EfficiencyLib.asSanitizedAddress(tokenId), msg.sender, newDestination, amountAfterDiscount);
         }
 

--- a/src/settlers/types/OrderPurchaseType.sol
+++ b/src/settlers/types/OrderPurchaseType.sol
@@ -9,7 +9,7 @@ struct OrderPurchase {
     address originSettler;
     address destination;
     bytes call;
-    uint48 discount;
+    uint64 discount;
     uint32 timeToBuy;
 }
 
@@ -20,11 +20,11 @@ struct OrderPurchase {
  * TYPE: Is complete including sub-types.
  */
 library OrderPurchaseType {
-    bytes constant ORDER_PURCHASE_TYPE_STUB = abi.encodePacked("OrderPurchase(" "bytes32 orderId," "address originSettler," "address destination," "bytes call," "uint48 discount," "uint32 timeToBuy" ")");
+    bytes constant ORDER_PURCHASE_TYPE_STUB = abi.encodePacked("OrderPurchase(" "bytes32 orderId," "address originSettler," "address destination," "bytes call," "uint64 discount," "uint32 timeToBuy" ")");
 
     bytes32 constant ORDER_PURCHASE_TYPE_HASH = keccak256(ORDER_PURCHASE_TYPE_STUB);
 
-    function hashOrderPurchase(bytes32 orderId, address originSettler, address destination, bytes calldata call, uint48 discount, uint32 timeToBuy) internal pure returns (bytes32) {
+    function hashOrderPurchase(bytes32 orderId, address originSettler, address destination, bytes calldata call, uint64 discount, uint32 timeToBuy) internal pure returns (bytes32) {
         return keccak256(abi.encode(ORDER_PURCHASE_TYPE_HASH, orderId, originSettler, destination, keccak256(call), discount, timeToBuy));
     }
 }


### PR DESCRIPTION
Use `uint64` for the `discount` parameter (since `DISCOUNT_DENOM` is 1e18 and thus too large for a `uint48`), and implement the discount calculation as `1-discount`.