### PR TITLE
Check dispute timestamp for collateral payout

### DIFF
--- a/src/oracles/bitcoin/BitcoinOracle.sol
+++ b/src/oracles/bitcoin/BitcoinOracle.sol
@@ -463,8 +463,9 @@ contract BitcoinOracle is BaseOracle {
         uint32 claimTimestamp = claimedOrder.claimTimestamp;
         uint96 multiplier = claimedOrder.multiplier;
         address disputer = claimedOrder.disputer;
+        uint32 disputeTimestamp = claimedOrder.disputeTimestamp;
 
-        if (sponsor != address(0) && fillTimestamp >= claimTimestamp) {
+        if (sponsor != address(0) && fillTimestamp >= claimTimestamp && (disputer == address(0) || fillTimestamp <= disputeTimestamp)) {
             bool disputed = disputer != address(0);
             // If the order has been disputed, we need to also collect the disputers collateral for the solver.
 


### PR DESCRIPTION
The current collateral payout on verification only checks whether the transaction matches the claim. It should also check whether the dispute happened before (within the dispute timestamp limits).

Notice that the dispute timestamp may be set in the future, after the dispute happened. This is to ensure that the dispute does not invalidate an in progress transaction.