### PR TITLE
Use a more explicit fill interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 !/broadcast
 /broadcast/*/31337/
 /broadcast/**/dry-run/
+broadcast/
 
 # Docs
 docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Compiler files
 cache/
 out/
+.wake/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/script/WormholeRelayer.s.sol
+++ b/script/WormholeRelayer.s.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import { Script } from "forge-std/Script.sol";
+import { WormholeOracle } from "src/oracles/wormhole/WormholeOracle.sol";
+
+contract WormholeRelayer is Script {
+    function relay(address receiveOracle, bytes calldata vaa) external {
+        vm.broadcast();
+        WormholeOracle(receiveOracle).receiveMessage(vaa);
+    }
+}

--- a/script/relayVaa.sh
+++ b/script/relayVaa.sh
@@ -1,0 +1,29 @@
+# Set the required variables
+chainId="$1"
+address="$2"
+sequence="$3"
+network="$4"
+address2="$5"
+RPC_URL="$6"
+PRIVATE_KEY="$7"
+
+# Call the API and get the vaaBytes (base64 encoded)
+vaaBytesBase64=$(curl -s -X 'GET' "https://api.testnet.wormholescan.io/v1/signed_vaa/${chainId}/${address}/${sequence}?network=${network}" -H 'accept: application/json' | jq -r '.vaaBytes')
+
+# Check if vaaBytes is empty or not
+if [[ -z "$vaaBytesBase64" ]]; then
+  echo "Error: vaaBytes not found in response."
+  exit 1
+fi
+
+# Convert base64 to hex
+vaaBytesHex=$(echo "$vaaBytesBase64" | base64 -d | xxd -p | tr -d '\n')
+
+echo $vaaBytesHex
+
+# cast call "${address2}" "receiveMessage(bytes)" "0x${vaaBytesHex}" --rpc-url "$RPC_URL" --trace
+# Execute the cast command to send the message
+# cast send "${address2}" "receiveMessage(bytes)" "0x${vaaBytesHex}" --rpc-url "$RPC_URL" --private-key "${PRIVATE_KEY}"
+
+# alt
+forge script WormholeRelayer --sig "relay(address,bytes)" "${address2}" "0x${vaaBytesHex}" --rpc-url "$RPC_URL" --private-key "${PRIVATE_KEY}" -vvvv --broadcast

--- a/snapshots/TestCatalyst.json
+++ b/snapshots/TestCatalyst.json
@@ -1,6 +1,6 @@
 {
-  "fillThrow": "63952",
-  "finaliseSelf": "70067",
+  "fillThrow": "63975",
+  "finaliseSelf": "70258",
   "receiveMessage": "45687",
   "submit": "14018"
 }

--- a/snapshots/TestCatalyst.json
+++ b/snapshots/TestCatalyst.json
@@ -1,6 +1,6 @@
 {
-  "fillThrow": "86580",
-  "finaliseSelf": "110009",
-  "receiveMessage": "73519",
-  "submit": "44486"
+  "fillThrow": "63952",
+  "finaliseSelf": "70067",
+  "receiveMessage": "45687",
+  "submit": "14018"
 }

--- a/src/fillers/BaseFiller.sol
+++ b/src/fillers/BaseFiller.sol
@@ -19,6 +19,7 @@ abstract contract BaseFiller is IPayloadCreator {
     error WrongChain(uint256 expected, uint256 actual); // 0x264363e1
     error WrongRemoteFiller(bytes32 addressThis, bytes32 expected);
     error ZeroValue(); // 0x7c946ed7
+    error FillDeadline();
 
     struct FilledOutput {
         bytes32 solver;
@@ -90,7 +91,9 @@ abstract contract BaseFiller is IPayloadCreator {
 
     // --- Solver Interface --- //
 
-    function fill(bytes32 orderId, OutputDescription calldata output, bytes32 proposedSolver) external returns (bytes32) {
+    function fill(uint32 fillDeadline, bytes32 orderId, OutputDescription calldata output, bytes32 proposedSolver) external returns (bytes32) {
+        if (fillDeadline < block.timestamp) revert FillDeadline();
+        
         return _fill(orderId, output, proposedSolver);
     }
 
@@ -112,7 +115,9 @@ abstract contract BaseFiller is IPayloadCreator {
      * @param outputs Order output descriptions. ENSURE that the FIRST output of the order is also the first output of this function.
      * @param proposedSolver Solver identifier that will be able to claim funds on the input chain.
      */
-    function fillBatch(bytes32 orderId, OutputDescription[] calldata outputs, bytes32 proposedSolver) external {
+    function fillBatch(uint32 fillDeadline, bytes32 orderId, OutputDescription[] calldata outputs, bytes32 proposedSolver) external {
+        if (fillDeadline < block.timestamp) revert FillDeadline();
+
         bytes32 actualSolver = _fill(orderId, outputs[0], proposedSolver);
         if (actualSolver != proposedSolver) revert FilledBySomeoneElse(actualSolver);
 

--- a/src/oracles/bitcoin/BitcoinOracle.sol
+++ b/src/oracles/bitcoin/BitcoinOracle.sol
@@ -531,7 +531,8 @@ contract BitcoinOracle is BaseOracle {
 
     /**
      * @notice Dispute an order.
-     * @param output TODO:
+     * @param orderId Order Identifier
+     * @param output Output description of the order to dispute.
      */
     function dispute(bytes32 orderId, OutputDescription calldata output) external {
         bytes32 outputId = _outputIdentifier(output);

--- a/src/settlers/compact/TheCompactOrderType.sol
+++ b/src/settlers/compact/TheCompactOrderType.sol
@@ -7,6 +7,7 @@ struct CatalystCompactOrder {
     address user;
     uint256 nonce;
     uint256 originChainId;
+    uint32 expires;
     uint32 fillDeadline;
     address localOracle;
     uint256[2][] inputs;

--- a/test/TestCatalyst.t.sol
+++ b/test/TestCatalyst.t.sol
@@ -239,22 +239,20 @@ contract TestCatalyst is Test {
         uint256[2][] memory idsAndAmounts = new uint256[2][](1);
         idsAndAmounts[0] = [tokenId, amount];
 
-        bytes32 orderHash = this.orderHash(order);
-        bytes memory sponsorSig = getCompactBatchWitnessSignature(swapperPrivateKey, typeHash, address(compactSettler), swapper, 0, type(uint32).max, idsAndAmounts, orderHash);
-        bytes memory allocatorSig = getCompactBatchWitnessSignature(allocatorPrivateKey, typeHash, address(compactSettler), swapper, 0, type(uint32).max, idsAndAmounts, orderHash);
+        bytes32 _orderHash = this.orderHash(order);
+        bytes memory sponsorSig = getCompactBatchWitnessSignature(swapperPrivateKey, typeHash, address(compactSettler), swapper, 0, type(uint32).max, idsAndAmounts, _orderHash);
+        bytes memory allocatorSig = getCompactBatchWitnessSignature(allocatorPrivateKey, typeHash, address(compactSettler), swapper, 0, type(uint32).max, idsAndAmounts, _orderHash);
 
         bytes memory signature = abi.encode(sponsorSig, allocatorSig);
 
         // Initiation is over. We need to fill the order.
 
         bytes32 solverIdentifier = bytes32(uint256(uint160((solver))));
-        bytes32[] memory orderIds = new bytes32[](1);
-
+        
         bytes32 orderId = compactSettler.orderIdentifier(order);
-        orderIds[0] = orderId;
 
         vm.prank(solver);
-        coinFiller.fillThrow(orderIds, outputs, solverIdentifier);
+        coinFiller.fill(orderId, outputs[0], solverIdentifier);
         vm.snapshotGasLastCall("fillThrow");
 
         bytes[] memory payloads = new bytes[](1);

--- a/test/TestCatalyst.t.sol
+++ b/test/TestCatalyst.t.sol
@@ -181,7 +181,7 @@ contract TestCatalyst is Test {
             fulfillmentContext: hex""
         });
         CatalystCompactOrder memory order =
-            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, localOracle: alwaysYesOracle, inputs: inputs, outputs: outputs });
+            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, expires: type(uint32).max, localOracle: alwaysYesOracle, inputs: inputs, outputs: outputs });
 
         // Make Compact
         bytes32 typeHash = TheCompactOrderType.BATCH_COMPACT_TYPE_HASH;
@@ -232,7 +232,7 @@ contract TestCatalyst is Test {
             fulfillmentContext: hex""
         });
         CatalystCompactOrder memory order =
-            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, localOracle: localOracle, inputs: inputs, outputs: outputs });
+            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, expires: type(uint32).max, localOracle: localOracle, inputs: inputs, outputs: outputs });
 
         // Make Compact
         bytes32 typeHash = TheCompactOrderType.BATCH_COMPACT_TYPE_HASH;
@@ -252,7 +252,7 @@ contract TestCatalyst is Test {
         bytes32 orderId = compactSettler.orderIdentifier(order);
 
         vm.prank(solver);
-        coinFiller.fill(orderId, outputs[0], solverIdentifier);
+        coinFiller.fill(type(uint32).max, orderId, outputs[0], solverIdentifier);
         vm.snapshotGasLastCall("fillThrow");
 
         bytes[] memory payloads = new bytes[](1);
@@ -313,7 +313,7 @@ contract TestCatalyst is Test {
             fulfillmentContext: hex""
         });
         CatalystCompactOrder memory order =
-            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, localOracle: localOracle, inputs: inputs, outputs: outputs });
+            CatalystCompactOrder({ user: address(swapper), nonce: 0, originChainId: block.chainid, fillDeadline: type(uint32).max, expires: type(uint32).max, localOracle: localOracle, inputs: inputs, outputs: outputs });
 
         // Make Compact
         bytes32 typeHash = TheCompactOrderType.BATCH_COMPACT_TYPE_HASH;
@@ -331,10 +331,10 @@ contract TestCatalyst is Test {
         bytes32 orderId = compactSettler.orderIdentifier(order);
 
         vm.prank(solver);
-        coinFiller.fill(orderId, outputs[0], solverIdentifier);
+        coinFiller.fill(type(uint32).max, orderId, outputs[0], solverIdentifier);
 
         vm.prank(solver);
-        coinFiller.fill(orderId, outputs[1], solverIdentifier2);
+        coinFiller.fill(type(uint32).max, orderId, outputs[1], solverIdentifier2);
 
         bytes[] memory payloads = new bytes[](2);
         payloads[0] = OutputEncodingLib.encodeFillDescriptionM(solverIdentifier, orderId, uint32(block.timestamp), outputs[0]);

--- a/test/fillers/coin/CoinFiller.t.sol
+++ b/test/fillers/coin/CoinFiller.t.sol
@@ -42,17 +42,15 @@ contract TestCoinFiller is Test {
 
     // --- VALID CASES --- //
 
-    function test_fill_skip(bytes32 orderId, address sender, bytes32 filler, uint256 amount) public {
+    function test_fill(bytes32 orderId, address sender, bytes32 filler, uint256 amount) public {
         vm.assume(filler != bytes32(0) && swapper != sender);
 
         outputToken.mint(sender, amount);
         vm.prank(sender);
         outputToken.approve(coinFillerAddress, amount);
 
-        bytes32[] memory orderIds = new bytes32[](1);
-        OutputDescription[] memory outputs = new OutputDescription[](1);
 
-        outputs[0] = OutputDescription({
+        OutputDescription memory output = OutputDescription({
             remoteFiller: bytes32(uint256(uint160(coinFillerAddress))),
             remoteOracle: bytes32(0),
             chainId: block.chainid,
@@ -62,31 +60,28 @@ contract TestCoinFiller is Test {
             remoteCall: bytes(""),
             fulfillmentContext: bytes("")
         });
-        orderIds[0] = orderId;
-
+    
         vm.prank(sender);
-
         vm.expectEmit();
-        emit OutputFilled(orderId, filler, uint32(block.timestamp), outputs[0]);
+        emit OutputFilled(orderId, filler, uint32(block.timestamp), output);
 
         vm.expectCall(outputTokenAddress, abi.encodeWithSignature("transferFrom(address,address,uint256)", sender, swapper, amount));
 
-        coinFiller.fillSkip(orderIds, outputs, filler);
+        coinFiller.fill(orderId, output, filler);
 
         assertEq(outputToken.balanceOf(swapper), amount);
         assertEq(outputToken.balanceOf(sender), 0);
     }
 
-    function test_fill_throw(bytes32 orderId, address sender, bytes32 filler, uint256 amount) public {
-        vm.assume(filler != bytes32(0) && swapper != sender);
+    function test_fill_batch(bytes32 orderId, address sender, bytes32 filler, bytes32 nextFiller, uint128 amount, uint128 amount2) public {
+        vm.assume(filler != bytes32(0) && swapper != sender && nextFiller != filler && nextFiller != bytes32(0) && amount != amount2);
 
-        outputToken.mint(sender, amount);
+        outputToken.mint(sender, uint256(amount) + uint256(amount2));
         vm.prank(sender);
-        outputToken.approve(coinFillerAddress, amount);
+        outputToken.approve(coinFillerAddress, uint256(amount) + uint256(amount2));
 
-        bytes32[] memory orderIds = new bytes32[](1);
-        OutputDescription[] memory outputs = new OutputDescription[](1);
 
+        OutputDescription[] memory outputs = new OutputDescription[](2);
         outputs[0] = OutputDescription({
             remoteFiller: bytes32(uint256(uint160(coinFillerAddress))),
             remoteOracle: bytes32(0),
@@ -97,18 +92,50 @@ contract TestCoinFiller is Test {
             remoteCall: bytes(""),
             fulfillmentContext: bytes("")
         });
-        orderIds[0] = orderId;
 
-        vm.prank(sender);
+        outputs[1] = OutputDescription({
+            remoteFiller: bytes32(uint256(uint160(coinFillerAddress))),
+            remoteOracle: bytes32(0),
+            chainId: block.chainid,
+            token: bytes32(uint256(uint160(outputTokenAddress))),
+            amount: amount2,
+            recipient: bytes32(uint256(uint160(swapper))),
+            remoteCall: bytes(""),
+            fulfillmentContext: bytes("")
+        });
+    
         vm.expectEmit();
         emit OutputFilled(orderId, filler, uint32(block.timestamp), outputs[0]);
+        emit OutputFilled(orderId, filler, uint32(block.timestamp), outputs[1]);
 
         vm.expectCall(outputTokenAddress, abi.encodeWithSignature("transferFrom(address,address,uint256)", sender, swapper, amount));
+        vm.expectCall(outputTokenAddress, abi.encodeWithSignature("transferFrom(address,address,uint256)", sender, swapper, amount2));
 
-        coinFiller.fillThrow(orderIds, outputs, filler);
+        uint256 prefillSnapshot = vm.snapshot();
 
-        assertEq(outputToken.balanceOf(swapper), amount);
+        vm.prank(sender);
+        coinFiller.fillBatch(orderId, outputs, filler);
+
+        assertEq(outputToken.balanceOf(swapper), uint256(amount) + uint256(amount2));
         assertEq(outputToken.balanceOf(sender), 0);
+
+        vm.revertTo(prefillSnapshot);
+        // Fill the first output by someone else. The other outputs won't be filled.
+        vm.prank(sender);
+        coinFiller.fill(orderId, outputs[0], nextFiller);
+
+        vm.expectRevert(abi.encodeWithSignature("FilledBySomeoneElse(bytes32)", (nextFiller)));
+        vm.prank(sender);
+        coinFiller.fillBatch(orderId, outputs, filler);
+
+        vm.revertTo(prefillSnapshot);
+        // Fill the second output by someone else. The first output will be filled.
+
+        vm.prank(sender);
+        coinFiller.fill(orderId, outputs[1], nextFiller);
+
+        vm.prank(sender);
+        coinFiller.fillBatch(orderId, outputs, filler);
     }
 
     function test_mock_callback_executor(address sender, bytes32 orderId, uint256 amount, bytes32 filler, bytes memory remoteCallData) public {
@@ -243,11 +270,7 @@ contract TestCoinFiller is Test {
         vm.prank(sender);
         outputToken.approve(coinFillerAddress, amount);
 
-        bytes32[] memory orderIds = new bytes32[](1);
-        OutputDescription[] memory outputs = new OutputDescription[](1);
-
-        orderIds[0] = orderId;
-        outputs[0] = OutputDescription({
+        OutputDescription memory output = OutputDescription({
             remoteFiller: bytes32(uint256(uint160(coinFillerAddress))),
             remoteOracle: bytes32(0),
             chainId: block.chainid,
@@ -259,10 +282,12 @@ contract TestCoinFiller is Test {
         });
 
         vm.prank(sender);
-        coinFiller.fillThrow(orderIds, outputs, filler);
+        coinFiller.fill(orderId, output, filler);
         vm.prank(sender);
-        vm.expectRevert(abi.encodeWithSelector(FilledBySomeoneElse.selector, filler));
-        coinFiller.fillThrow(orderIds, outputs, differentFiller);
+        bytes32 alreadyFilledBy = coinFiller.fill(orderId, output, differentFiller);
+
+        assertNotEq(alreadyFilledBy, differentFiller);
+        assertEq(alreadyFilledBy, filler);
     }
 
     function test_call_with_real_address(address sender, uint256 amount) public {

--- a/test/oracle/wormhole/submit.t.sol
+++ b/test/oracle/wormhole/submit.t.sol
@@ -70,7 +70,7 @@ contract TestSubmitWormholeOracleProofs is Test {
         vm.expectCall(address(token), abi.encodeWithSignature("transferFrom(address,address,uint256)", address(sender), recipient, amount));
 
         vm.prank(sender);
-        filler.fill(orderId, output, solverIdentifier);
+        filler.fill(type(uint32).max, orderId, output, solverIdentifier);
 
         bytes memory payload = OutputEncodingLib.encodeFillDescriptionM(solverIdentifier, orderId, uint32(block.timestamp), output);
         bytes[] memory payloads = new bytes[](1);


### PR DESCRIPTION
This PR introduces a new fill interface. Instead of `FillThrow` and `FillSkip` which throws if 1 fill has already been filled or does not throw, respectively a new interface `fillBatch` is introduced that fills the first output iff that output has not been filled, the remaining outputs will be filled. (through if any has already been filled, they are skipped)

This is an attempt to bake in fill assumptions: The first output of each intent determines the solver. As a result, that output is important to fill before filling the remaining outputs.

If an intent contains multiple outputs all for a single chain, if the outputs are taken as is, as ordered, given to the `fillBatch` function, that call will either fill the entire order or not.

Outputs can still be individually filled or batched from an external contract.