### PR TITLE
[API-699] feat(polymer): Solana -> EVM proof path

### DIFF
--- a/src/integrations/oracles/polymer/Base58.sol
+++ b/src/integrations/oracles/polymer/Base58.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/**
+ * @title Base58
+ * @notice Minimal on-chain Base58 encoder using the Bitcoin/Solana alphabet.
+ * @dev Implements the canonical "big-number" base58 encoding (as used by Bitcoin/Solana): the input is treated as a
+ *      big-endian integer, repeatedly divided by 58, and each leading `0x00` byte maps to one leading `'1'` character.
+ *      This is the exact rendering Solana uses for program ids (e.g. bytes32
+ *      `0x06ddf6e1...eff00a9` -> "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").
+ */
+library Base58 {
+    /// @dev Bitcoin/Solana base58 alphabet (no 0, O, I, l).
+    bytes internal constant ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+    /**
+     * @notice Base58-encodes an arbitrary byte string.
+     * @param data The raw bytes to encode.
+     * @return The base58 string.
+     */
+    function encode(
+        bytes memory data
+    ) internal pure returns (string memory) {
+        uint256 dataLen = data.length;
+        if (dataLen == 0) return "";
+
+        // Count leading zero bytes; each maps to a leading '1'.
+        uint256 zeros = 0;
+        while (zeros < dataLen && data[zeros] == 0x00) {
+            ++zeros;
+        }
+
+        // Upper bound on the number of base58 digits: log(256)/log(58) ~= 1.365, so 138/100 + 1 is safe.
+        uint256 size = ((dataLen - zeros) * 138) / 100 + 1;
+        bytes memory b58 = new bytes(size);
+
+        // Process each remaining byte as "b58 = b58 * 256 + byte", accumulating base58 digits from the LSB end.
+        uint256 length = 0;
+        for (uint256 i = zeros; i < dataLen; ++i) {
+            uint256 carry = uint256(uint8(data[i]));
+            uint256 k = 0;
+            for (uint256 rev = 0; rev < size; ++rev) {
+                if (carry == 0 && k >= length) break;
+                uint256 idx = size - 1 - rev;
+                carry += 256 * uint256(uint8(b58[idx]));
+                b58[idx] = bytes1(uint8(carry % 58));
+                carry /= 58;
+                ++k;
+            }
+            length = k;
+        }
+
+        // The significant digits occupy b58[size - length : size].
+        uint256 start = size - length;
+
+        bytes memory out = new bytes(zeros + length);
+        for (uint256 i = 0; i < zeros; ++i) {
+            out[i] = ALPHABET[0]; // '1'
+        }
+        for (uint256 i = 0; i < length; ++i) {
+            out[zeros + i] = ALPHABET[uint8(b58[start + i])];
+        }
+        return string(out);
+    }
+
+    /**
+     * @notice Base58-encodes a 32-byte value (e.g. a Solana program id), preserving leading zero bytes.
+     * @param data The 32-byte value to encode.
+     * @return The base58 string.
+     */
+    function encode(
+        bytes32 data
+    ) internal pure returns (string memory) {
+        bytes memory buf = new bytes(32);
+        assembly {
+            mstore(add(buf, 32), data)
+        }
+        return encode(buf);
+    }
+}

--- a/src/integrations/oracles/polymer/PolymerOracle.sol
+++ b/src/integrations/oracles/polymer/PolymerOracle.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.26;
 
 import { LibAddress } from "../../../libs/LibAddress.sol";
+import { Base64 } from "openzeppelin/utils/Base64.sol";
 import { Bytes } from "openzeppelin/utils/Bytes.sol";
 
 import { MandateOutput, MandateOutputEncodingLib } from "../../../libs/MandateOutputEncodingLib.sol";
@@ -19,6 +20,16 @@ contract PolymerOracle is BaseInputOracle {
     using LibAddress for address;
 
     error WrongEventSignature();
+    error NotSolanaMessage();
+    error InvalidSolanaMessage();
+    error MalformedSolanaLog();
+
+    uint256 constant SOLANA_POLYMER_CHAIN_ID = 2;
+
+    // On-wire Solana blob layout offsets. Layout (a): `application(32) || payload(dynamic)`.
+    // To switch to layout (b) `program_id(32) || emitter(32) || application(32) || payload`, set these to 64 and 96.
+    uint256 constant SOLANA_APPLICATION_OFFSET = 0;
+    uint256 constant SOLANA_PAYLOAD_OFFSET = 32;
 
     ICrossL2ProverV2 CROSS_L2_PROVER;
 
@@ -34,6 +45,8 @@ contract PolymerOracle is BaseInputOracle {
         return protocolId;
     }
 
+    /// ************** EVM Processing ************** ///
+
     function _proofPayloadHash(
         bytes32 orderId,
         bytes32 solver,
@@ -44,7 +57,7 @@ contract PolymerOracle is BaseInputOracle {
             keccak256(MandateOutputEncodingLib.encodeFillDescriptionMemory(solver, orderId, timestamp, mandateOutput));
     }
 
-    function _processMessage(
+    function _processEvmMessage(
         bytes calldata proof
     ) internal {
         (uint32 chainId, address emittingContract, bytes memory topics, bytes memory unindexedData) =
@@ -83,10 +96,87 @@ contract PolymerOracle is BaseInputOracle {
         emit OutputProven(remoteChainId, address(this).toIdentifier(), application, payloadHash);
     }
 
+    /// ************** Solana Processing ************** ///
+
+    /**
+     * @dev Processes a Solana proof.
+     *
+     * Trust model: the only value Polymer authenticates for a Solana proof is `returnedProgramId` (the program id
+     * returned by `validateSolLogs`, taken from the proven receipt). The remote-oracle/sender identity is therefore
+     * taken from `returnedProgramId` and NEVER from the log content (which is attacker-controllable). This mirrors the
+     * EVM path, which keys the sender identity on `address(this)` rather than on log data.
+     *
+     * This self-namespaces attestations: an attacker deploying their own Solana program `P` can only ever write
+     * attestations under `_attestations[chain][P][...]`. Honest orders reference the real program id as
+     * `output.oracle`, so a forged proof lands in a slot no honest order reads. No allowlist is required.
+     *
+     * Log format: `validateSolLogs` returns each log as a human-readable string of the form
+     * `"program: <base58 program id>, <base64 blob>"` (the on-chain `"Prove: "` prefix is already stripped by
+     * Polymer). Only the trailing base64 blob is decoded; it is extracted as the substring after the first `", "`
+     * delimiter (the base58 program id contains no comma).
+     *
+     * On-wire blob layout (a) `application(32) || payload(dynamic)`:
+     * - bytes[0:32]   = `application` (bytes32)  // application/settler identifier (source)
+     * - bytes[32:]    = `payload` (bytes)        // raw payload bytes (dynamic length)
+     *
+     * TODO(SVM): the Solana emitter `oracle_polymer::submit` currently emits
+     * `base64(program_id || oracle_polymer_pubkey || source || payload)` (4 fields). For layout (a) the SVM emit must
+     * be trimmed to `base64(source || payload)`. Do not touch the SVM here; if the identity is instead a PDA, switch
+     * to layout (b) by setting SOLANA_APPLICATION_OFFSET/SOLANA_PAYLOAD_OFFSET to 64/96.
+     */
+    function _processSolanaMessage(
+        bytes calldata proof
+    ) internal {
+        (uint32 chainId, bytes32 returnedProgramId, string[] memory logMessages) =
+            CROSS_L2_PROVER.validateSolLogs(proof);
+
+        require(chainId == SOLANA_POLYMER_CHAIN_ID, NotSolanaMessage());
+
+        uint256 remoteChainId = _getChainId(uint256(chainId));
+
+        for (uint256 i = 0; i < logMessages.length; i++) {
+            bytes memory logBytes = Base64.decode(_extractSolanaLogBlob(logMessages[i]));
+
+            if (logBytes.length < SOLANA_PAYLOAD_OFFSET) revert InvalidSolanaMessage();
+
+            bytes32 application =
+                bytes32(Bytes.slice(logBytes, SOLANA_APPLICATION_OFFSET, SOLANA_APPLICATION_OFFSET + 32));
+            bytes32 payloadHash = keccak256(Bytes.slice(logBytes, SOLANA_PAYLOAD_OFFSET, logBytes.length));
+
+            // Sender identity is the Polymer-authenticated program id, never log content.
+            _attestations[remoteChainId][returnedProgramId][application][payloadHash] = true;
+
+            emit OutputProven(remoteChainId, returnedProgramId, application, payloadHash);
+        }
+    }
+
+    /**
+     * @dev Extracts the trailing base64 blob from a Solana log string of the form
+     * `"program: <base58 program id>, <base64 blob>"`. Returns the substring after the first `", "` delimiter.
+     * Reverts with {MalformedSolanaLog} if the delimiter is missing.
+     */
+    function _extractSolanaLogBlob(
+        string memory logMessage
+    ) internal pure returns (string memory) {
+        bytes memory logBytes = bytes(logMessage);
+        for (uint256 i = 0; i + 1 < logBytes.length; ++i) {
+            // Find the first ", " (0x2c 0x20) delimiter.
+            if (logBytes[i] == 0x2c && logBytes[i + 1] == 0x20) {
+                uint256 start = i + 2;
+                bytes memory blob = new bytes(logBytes.length - start);
+                for (uint256 j = 0; j < blob.length; ++j) {
+                    blob[j] = logBytes[start + j];
+                }
+                return string(blob);
+            }
+        }
+        revert MalformedSolanaLog();
+    }
+
     function receiveMessage(
         bytes calldata proof
     ) external {
-        _processMessage(proof);
+        _processEvmMessage(proof);
     }
 
     function receiveMessage(
@@ -94,7 +184,30 @@ contract PolymerOracle is BaseInputOracle {
     ) external {
         uint256 numProofs = proofs.length;
         for (uint256 i; i < numProofs; ++i) {
-            _processMessage(proofs[i]);
+            _processEvmMessage(proofs[i]);
+        }
+    }
+
+    /**
+     * @notice Processes a single Solana proof and updates the attestation state.
+     * @param proof The proof data from Solana to be processed.
+     */
+    function receiveSolanaMessage(
+        bytes calldata proof
+    ) external {
+        _processSolanaMessage(proof);
+    }
+
+    /**
+     * @notice Processes multiple Solana proofs and updates the attestation state for each.
+     * @param proofs An array of proof data from Solana to be processed.
+     */
+    function receiveSolanaMessage(
+        bytes[] calldata proofs
+    ) external {
+        uint256 numProofs = proofs.length;
+        for (uint256 i; i < numProofs; ++i) {
+            _processSolanaMessage(proofs[i]);
         }
     }
 }

--- a/src/integrations/oracles/polymer/PolymerOracle.sol
+++ b/src/integrations/oracles/polymer/PolymerOracle.sol
@@ -5,6 +5,8 @@ import { LibAddress } from "../../../libs/LibAddress.sol";
 import { Base64 } from "openzeppelin/utils/Base64.sol";
 import { Bytes } from "openzeppelin/utils/Bytes.sol";
 
+import { Base58 } from "./Base58.sol";
+
 import { MandateOutput, MandateOutputEncodingLib } from "../../../libs/MandateOutputEncodingLib.sol";
 
 import { OutputVerificationLib } from "../../../libs/OutputVerificationLib.sol";
@@ -22,7 +24,7 @@ contract PolymerOracle is BaseInputOracle {
     error WrongEventSignature();
     error NotSolanaMessage();
     error InvalidSolanaMessage();
-    error MalformedSolanaLog();
+    error SolanaProgramIdMismatch();
 
     uint256 internal constant SOLANA_POLYMER_CHAIN_ID = 2;
 
@@ -106,18 +108,26 @@ contract PolymerOracle is BaseInputOracle {
      * taken from `returnedProgramId` and NEVER from the log content (which is attacker-controllable). This mirrors the
      * EVM path, which keys the sender identity on `address(this)` rather than on log data.
      *
-     * This self-namespaces attestations: an attacker deploying their own Solana program `P` can only ever write
-     * attestations under `_attestations[chain][P][...]`. Honest orders reference the real program id as
-     * `output.oracle`, so a forged proof lands in a slot no honest order reads. No allowlist is required.
+     * ENFORCED program-id binding: each Solana log embeds the program id in its own human-readable prefix. Per
+     * Polymer's Solana-proving integration guidance, the program id returned by the prover MUST match the program id
+     * named in each proven log. We enforce this on-chain: every log is required to begin with exactly
+     * `"program: " + base58(returnedProgramId) + ", "` (see {_extractSolanaLogBlob}), reverting with
+     * {SolanaProgramIdMismatch} otherwise. This closes the gap where a mismatching (returnedProgramId, in-log id) pair
+     * could be accepted while the in-log id was silently discarded. The attestation is still keyed on the
+     * authenticated `returnedProgramId`, never on log content.
+     *
+     * Because the binding is enforced, attestations self-namespace: an attacker's Solana program can only produce logs
+     * that name (and are authenticated as) the attacker's own program id, so a forged proof can only ever write under
+     * `_attestations[chain][attackerProgramId][...]`. Honest orders reference the real program id as `output.oracle`,
+     * so a forged proof lands in a slot no honest order reads. No allowlist is required.
      *
      * Log format: `validateSolLogs` returns each log as a human-readable string of the form
      * `"program: <base58 program id>, <base64 blob>"` (the on-chain `"Prove: "` prefix is already stripped by
-     * Polymer). Only the trailing base64 blob is decoded; it is extracted as the substring after the first `", "`
-     * delimiter (the base58 program id contains no comma).
+     * Polymer). After the authenticated prefix is matched, the trailing base64 blob is decoded.
      *
      * On-wire blob layout `application(32) || payload(dynamic)`:
      * - bytes[0:32]   = `application` (bytes32)  // application/settler identifier (source)
-     * - bytes[32:]    = `payload` (bytes)        // raw payload bytes (dynamic length)
+     * - bytes[32:]    = `payload` (bytes)        // raw payload bytes (dynamic length; must be non-empty)
      *
      * The Solana emitter `oracle_polymer::submit` emits `base64(source || payload)`: `source` is the
      * 32-byte `application` at offset 0 and `payload` follows at offset 32.
@@ -132,10 +142,18 @@ contract PolymerOracle is BaseInputOracle {
 
         uint256 remoteChainId = _getChainId(uint256(chainId));
 
-        for (uint256 i = 0; i < logMessages.length; ++i) {
-            bytes memory logBytes = Base64.decode(_extractSolanaLogBlob(logMessages[i]));
+        // `Base58.encode(returnedProgramId)` is invariant across all logs in this proof and expensive to compute, so
+        // build the expected authenticated prefix once and reuse it for every log.
+        bytes memory expectedPrefix = abi.encodePacked("program: ", Base58.encode(returnedProgramId), ", ");
 
-            if (logBytes.length < SOLANA_PAYLOAD_OFFSET) revert InvalidSolanaMessage();
+        for (uint256 i = 0; i < logMessages.length; ++i) {
+            // The in-log program id is bound to the Polymer-authenticated `returnedProgramId`: the log must begin with
+            // exactly `"program: " + base58(returnedProgramId) + ", "`, otherwise this reverts.
+            bytes memory logBytes = Base64.decode(_extractSolanaLogBlob(logMessages[i], expectedPrefix));
+
+            // Require a NON-empty payload: length must be strictly greater than the application field (offset 32), so
+            // a bare 32-byte blob (empty payload hashing to keccak256("")) is rejected.
+            if (logBytes.length <= SOLANA_PAYLOAD_OFFSET) revert InvalidSolanaMessage();
 
             bytes32 application =
                 bytes32(Bytes.slice(logBytes, SOLANA_APPLICATION_OFFSET, SOLANA_APPLICATION_OFFSET + 32));
@@ -150,25 +168,30 @@ contract PolymerOracle is BaseInputOracle {
 
     /**
      * @dev Extracts the trailing base64 blob from a Solana log string of the form
-     * `"program: <base58 program id>, <base64 blob>"`. Returns the substring after the first `", "` delimiter.
-     * Reverts with {MalformedSolanaLog} if the delimiter is missing.
+     * `"program: <base58 program id>, <base64 blob>"`, binding the in-log program id to the Polymer-authenticated
+     * `returnedProgramId`. The log MUST begin with exactly the precomputed `expectedPrefix`
+     * (`"program: " + base58(returnedProgramId) + ", "`); the returned blob is the remainder after that prefix. The
+     * caller precomputes `expectedPrefix` once per proof because `Base58.encode` is expensive. Reverts with
+     * {SolanaProgramIdMismatch} if the log does not carry the expected authenticated prefix (this also covers a
+     * missing/malformed `"program: ..., "` wrapper).
      */
     function _extractSolanaLogBlob(
-        string memory logMessage
+        string memory logMessage,
+        bytes memory expectedPrefix
     ) internal pure returns (string memory) {
         bytes memory logBytes = bytes(logMessage);
-        for (uint256 i = 0; i + 1 < logBytes.length; ++i) {
-            // Find the first ", " (0x2c 0x20) delimiter.
-            if (logBytes[i] == 0x2c && logBytes[i + 1] == 0x20) {
-                uint256 start = i + 2;
-                bytes memory blob = new bytes(logBytes.length - start);
-                for (uint256 j = 0; j < blob.length; ++j) {
-                    blob[j] = logBytes[start + j];
-                }
-                return string(blob);
-            }
+        uint256 prefixLen = expectedPrefix.length;
+
+        if (logBytes.length < prefixLen) revert SolanaProgramIdMismatch();
+        for (uint256 i = 0; i < prefixLen; ++i) {
+            if (logBytes[i] != expectedPrefix[i]) revert SolanaProgramIdMismatch();
         }
-        revert MalformedSolanaLog();
+
+        bytes memory blob = new bytes(logBytes.length - prefixLen);
+        for (uint256 j = 0; j < blob.length; ++j) {
+            blob[j] = logBytes[prefixLen + j];
+        }
+        return string(blob);
     }
 
     function receiveMessage(

--- a/src/integrations/oracles/polymer/PolymerOracle.sol
+++ b/src/integrations/oracles/polymer/PolymerOracle.sol
@@ -24,14 +24,14 @@ contract PolymerOracle is BaseInputOracle {
     error InvalidSolanaMessage();
     error MalformedSolanaLog();
 
-    uint256 constant SOLANA_POLYMER_CHAIN_ID = 2;
+    uint256 internal constant SOLANA_POLYMER_CHAIN_ID = 2;
 
-    // On-wire Solana blob layout offsets. Layout (a): `application(32) || payload(dynamic)`.
-    // To switch to layout (b) `program_id(32) || emitter(32) || application(32) || payload`, set these to 64 and 96.
-    uint256 constant SOLANA_APPLICATION_OFFSET = 0;
-    uint256 constant SOLANA_PAYLOAD_OFFSET = 32;
+    // On-wire Solana blob layout: `application(32) || payload(dynamic)`.
+    // The application identifier is at offset 0; the payload follows at offset 32.
+    uint256 internal constant SOLANA_APPLICATION_OFFSET = 0;
+    uint256 internal constant SOLANA_PAYLOAD_OFFSET = 32;
 
-    ICrossL2ProverV2 CROSS_L2_PROVER;
+    ICrossL2ProverV2 internal immutable CROSS_L2_PROVER;
 
     constructor(
         address crossL2Prover
@@ -115,14 +115,12 @@ contract PolymerOracle is BaseInputOracle {
      * Polymer). Only the trailing base64 blob is decoded; it is extracted as the substring after the first `", "`
      * delimiter (the base58 program id contains no comma).
      *
-     * On-wire blob layout (a) `application(32) || payload(dynamic)`:
+     * On-wire blob layout `application(32) || payload(dynamic)`:
      * - bytes[0:32]   = `application` (bytes32)  // application/settler identifier (source)
      * - bytes[32:]    = `payload` (bytes)        // raw payload bytes (dynamic length)
      *
-     * TODO(SVM): the Solana emitter `oracle_polymer::submit` currently emits
-     * `base64(program_id || oracle_polymer_pubkey || source || payload)` (4 fields). For layout (a) the SVM emit must
-     * be trimmed to `base64(source || payload)`. Do not touch the SVM here; if the identity is instead a PDA, switch
-     * to layout (b) by setting SOLANA_APPLICATION_OFFSET/SOLANA_PAYLOAD_OFFSET to 64/96.
+     * The Solana emitter `oracle_polymer::submit` emits `base64(source || payload)`: `source` is the
+     * 32-byte `application` at offset 0 and `payload` follows at offset 32.
      */
     function _processSolanaMessage(
         bytes calldata proof
@@ -130,11 +128,11 @@ contract PolymerOracle is BaseInputOracle {
         (uint32 chainId, bytes32 returnedProgramId, string[] memory logMessages) =
             CROSS_L2_PROVER.validateSolLogs(proof);
 
-        require(chainId == SOLANA_POLYMER_CHAIN_ID, NotSolanaMessage());
+        if (chainId != SOLANA_POLYMER_CHAIN_ID) revert NotSolanaMessage();
 
         uint256 remoteChainId = _getChainId(uint256(chainId));
 
-        for (uint256 i = 0; i < logMessages.length; i++) {
+        for (uint256 i = 0; i < logMessages.length; ++i) {
             bytes memory logBytes = Base64.decode(_extractSolanaLogBlob(logMessages[i]));
 
             if (logBytes.length < SOLANA_PAYLOAD_OFFSET) revert InvalidSolanaMessage();

--- a/src/integrations/oracles/polymer/external/interfaces/ICrossL2ProverV2.sol
+++ b/src/integrations/oracles/polymer/external/interfaces/ICrossL2ProverV2.sol
@@ -54,4 +54,15 @@ interface ICrossL2ProverV2 {
     function inspectPolymerState(
         bytes calldata proof
     ) external pure returns (bytes32 stateRoot, uint64 height, bytes memory signature);
+
+    /**
+     * @notice Validates a proof and extracts Solana log messages from the provided proof.
+     * @param proof The proof data containing the necessary information to validate and extract logs.
+     * @return chainId The chain ID that the proof is for.
+     * @return programID The Solana program ID that emitted the logs.
+     * @return logMessages The array of log messages emitted by the program in the transaction.
+     */
+    function validateSolLogs(
+        bytes calldata proof
+    ) external view returns (uint32 chainId, bytes32 programID, string[] memory logMessages);
 }

--- a/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
+++ b/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
@@ -26,6 +26,27 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
     // Event for proof generation
     event ProofGenerated(bytes proof);
 
+    // --- Mock-specific errors --- //
+    error NoTopics();
+    error InvalidValidatorContract();
+    error ValidationCallFailed();
+    error EventEndExceedsProofLength();
+    error TopicsLengthMismatch();
+    error NoLogMessages();
+    error TooManyLogMessages();
+    error LogMessageEndExceedsProofLength();
+    error LogMessageEndExceedsUint16();
+
+    // --- Shared proof layout offsets (used by both the validators and the mock proof builders) --- //
+    /// @dev Source chain id occupies proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4].
+    uint256 internal constant CHAIN_ID_OFFSET = 97;
+    /// @dev Number of Solana log messages is a single byte at proof[SOL_NUM_LOGS_OFFSET].
+    uint256 internal constant SOL_NUM_LOGS_OFFSET = 117;
+    /// @dev Solana program id occupies proof[SOL_PROGRAM_ID_OFFSET:SOL_PROGRAM_ID_OFFSET + 32].
+    uint256 internal constant SOL_PROGRAM_ID_OFFSET = 182;
+    /// @dev First Solana log entry begins at proof[SOL_LOG_DATA_OFFSET] (right after the fixed header).
+    uint256 internal constant SOL_LOG_DATA_OFFSET = 214;
+
     constructor(
         string memory clientType_,
         address sequencer_,
@@ -46,7 +67,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes32[] memory topics,
         bytes memory data
     ) external returns (bytes memory) {
-        require(topics.length > 0, "At least one topic (event signature) required");
+        if (topics.length == 0) revert NoTopics();
 
         bytes memory proof = generateMockProof(chainId_, uint8(topics.length), emitter, topics, data);
 
@@ -70,14 +91,14 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes memory data,
         address validatorContract
     ) external returns (bytes memory) {
-        require(topics.length > 0, "At least one topic (event signature) required");
-        require(validatorContract != address(0), "Invalid validator contract address");
+        if (topics.length == 0) revert NoTopics();
+        if (validatorContract == address(0)) revert InvalidValidatorContract();
 
         bytes memory proof = generateMockProof(chainId_, uint8(topics.length), emitter, topics, data);
 
         // Call the validator contract's validateEvent function
         (bool success,) = validatorContract.call(abi.encodeWithSignature("validateEvent(bytes)", proof));
-        require(success, "Validation call failed");
+        if (!success) revert ValidationCallFailed();
 
         return proof;
     }
@@ -94,8 +115,8 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         override
         returns (uint32 chainId, address emittingContract, bytes memory topics, bytes memory unindexedData)
     {
-        // Extract chainId from proof[97:101]
-        chainId = uint32(bytes4(proof[97:101]));
+        // Extract chainId from proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4]
+        chainId = uint32(bytes4(proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4]));
 
         // Skip sequencer signature verification (normally done with _verifySequencerSignature)
         // In production, this ensures the proof is signed by the sequencer, but for testing,
@@ -103,7 +124,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
 
         // Calculate event end from proof[121:123]
         uint256 eventEnd = uint256(uint16(bytes2(proof[121:123])));
-        require(eventEnd <= proof.length, "Event end exceeds proof length");
+        if (eventEnd > proof.length) revert EventEndExceedsProofLength();
         bytes memory rawEvent = proof[123:eventEnd];
 
         // Skip IAVL proof verification (normally done with verifyMembership)
@@ -121,18 +142,18 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
     function validateSolLogs(
         bytes calldata proof
     ) external pure override returns (uint32 chainId, bytes32 programID, string[] memory logMessages) {
-        // Extract chainId from proof[97:101]
-        chainId = uint32(bytes4(proof[97:101]));
+        // Extract chainId from proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4]
+        chainId = uint32(bytes4(proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4]));
 
         // Skip sequencer signature verification (normally done with _verifySequencerSignature)
         // In production, this ensures the proof is signed by the sequencer, but for testing,
         // we assume a valid signature.
 
-        // Extract programID from proof[182:214]
-        programID = bytes32(proof[182:214]);
+        // Extract programID from proof[SOL_PROGRAM_ID_OFFSET:SOL_PROGRAM_ID_OFFSET + 32]
+        programID = bytes32(proof[SOL_PROGRAM_ID_OFFSET:SOL_PROGRAM_ID_OFFSET + 32]);
 
-        // Extract number of log messages from proof[117]
-        uint8 numLogMessages = uint8(proof[117]);
+        // Extract number of log messages from proof[SOL_NUM_LOGS_OFFSET]
+        uint8 numLogMessages = uint8(proof[SOL_NUM_LOGS_OFFSET]);
         logMessages = new string[](numLogMessages);
 
         // Parse log messages
@@ -145,13 +166,13 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         // So the first log looks like:
         //   [ log0_end (2 bytes) ][ log0_bytes ... up to log0_end-1 ]
         // The second log immediately follows, starting at log0_end, with its own 2-byte end offset, etc.
-        uint256 currLogMessageStart = 214;
-        uint256 currentLogMessageEnd = 214; // Initialised for the 0-log edge case
+        uint256 currLogMessageStart = SOL_LOG_DATA_OFFSET;
+        uint256 currentLogMessageEnd = SOL_LOG_DATA_OFFSET; // Initialised for the 0-log edge case
 
         for (uint256 i = 0; i < logMessages.length; ++i) {
             // Read the absolute end offset of this log's bytes
             currentLogMessageEnd = uint16(bytes2(proof[currLogMessageStart:currLogMessageStart + 2]));
-            require(currentLogMessageEnd <= proof.length, "Log message end exceeds proof length");
+            if (currentLogMessageEnd > proof.length) revert LogMessageEndExceedsProofLength();
 
             // Slice out the log string bytes (skip the 2-byte end offset)
             logMessages[i] = string(proof[currLogMessageStart + 2:currentLogMessageEnd]);
@@ -181,7 +202,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes32[] memory topics_,
         bytes memory unindexedData_
     ) public pure returns (bytes memory) {
-        require(topics_.length == numTopics, "Topics length mismatch");
+        if (topics_.length != numTopics) revert TopicsLengthMismatch();
 
         // Calculate lengths
         uint256 topicsLength = numTopics * 32;
@@ -199,7 +220,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         // populate given chainId (4 bytes)
         bytes4 chainIdBytes = bytes4(chainId_);
         for (uint256 i = 0; i < 4; i++) {
-            proof[97 + i] = chainIdBytes[i];
+            proof[CHAIN_ID_OFFSET + i] = chainIdBytes[i];
         }
         // peptideHeight (proof[101:109]) dummy value of 100
         proof[108] = bytes1(uint8(100));
@@ -243,10 +264,15 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
     }
 
     /**
-     * @dev Formats a Solana log line exactly as `validateSolLogs` returns it: a human-readable string of the form
+     * @dev Formats a Solana log line in the shape `validateSolLogs` returns: a human-readable string of the form
      *      `"program: <base58 program id>, <base64 blob>"` (the on-chain `"Prove: "` prefix is already stripped).
-     *      The base58 program id is stand-in-encoded here as hex, which is sufficient for exercising the parser (it
-     *      contains no `", "` delimiter). The trailing base64 blob is what the oracle actually decodes.
+     *
+     *      SIMPLIFICATION: real Polymer renders the program id in base58; this mock renders it in HEX instead. On-chain
+     *      base58 encoding is impractical (no cheap library) and the rendered program id is purely cosmetic here — the
+     *      oracle never parses it, extracting only the trailing base64 blob after the first `", "` delimiter (and hex,
+     *      like base58, contains no `", "`). True base58 fidelity is pinned separately by the immutable
+     *      `test_receiveSolanaMessage_golden_fixture` tests, which hardcode a real base58 program id in the log line.
+     *      The trailing base64 blob is what the oracle actually decodes.
      * @param programId Solana program id embedded in the human-readable prefix.
      * @param blob Raw bytes to be base64-encoded as the log payload.
      * @return The formatted log string.
@@ -272,7 +298,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes32 programID,
         string[] memory logMessages
     ) external returns (bytes memory) {
-        require(logMessages.length > 0, "At least one log message required");
+        if (logMessages.length == 0) revert NoLogMessages();
 
         bytes memory proof = generateMockSolProof(chainId_, programID, logMessages);
 
@@ -292,8 +318,8 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes32 programID,
         string[] memory logMessages_
     ) public pure returns (bytes memory) {
-        require(logMessages_.length > 0, "At least one log message required");
-        require(logMessages_.length <= 255, "Too many log messages");
+        if (logMessages_.length == 0) revert NoLogMessages();
+        if (logMessages_.length > 255) revert TooManyLogMessages();
 
         // Calculate total length of all log messages
         uint256 totalLogLength = 0;
@@ -302,10 +328,11 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         }
 
         // Calculate proof length:
-        // - Fixed header: 214 bytes (state root + signature + chainId + heights + numLogs + txSig + programID)
+        // - Fixed header: SOL_LOG_DATA_OFFSET bytes (state root + signature + chainId + heights + numLogs + txSig +
+        //   programID)
         // - Log messages: totalLogLength bytes
         // - IAVL proof: 32 bytes (dummy)
-        uint256 proofLength = 214 + totalLogLength + 32;
+        uint256 proofLength = SOL_LOG_DATA_OFFSET + totalLogLength + 32;
 
         bytes memory proof = new bytes(proofLength);
 
@@ -313,10 +340,10 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         // - stateRoot (32 bytes): dummy
         // - signature (65 bytes): dummy
 
-        // Populate chainId (4 bytes) at proof[97:101]
+        // Populate chainId (4 bytes) at proof[CHAIN_ID_OFFSET:CHAIN_ID_OFFSET + 4]
         bytes4 chainIdBytes = bytes4(chainId_);
         for (uint256 i = 0; i < 4; i++) {
-            proof[97 + i] = chainIdBytes[i];
+            proof[CHAIN_ID_OFFSET + i] = chainIdBytes[i];
         }
 
         // peptideHeight (proof[101:109]) - dummy value of 100
@@ -325,24 +352,24 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         // blockHeight (proof[109:117]) - dummy value of 200
         proof[116] = bytes1(uint8(200));
 
-        // number of log messages (proof[117])
-        proof[117] = bytes1(uint8(logMessages_.length));
+        // number of log messages (proof[SOL_NUM_LOGS_OFFSET])
+        proof[SOL_NUM_LOGS_OFFSET] = bytes1(uint8(logMessages_.length));
 
         // txSignature high (proof[118:150]) - dummy value
         // txSignature low (proof[150:182]) - dummy value
         // (already 0)
 
-        // programID (proof[182:214])
+        // programID (proof[SOL_PROGRAM_ID_OFFSET:SOL_PROGRAM_ID_OFFSET + 32])
         for (uint256 i = 0; i < 32; i++) {
-            proof[182 + i] = programID[i];
+            proof[SOL_PROGRAM_ID_OFFSET + i] = programID[i];
         }
 
-        // Encode log messages starting at proof[214]
-        uint256 offset = 214;
+        // Encode log messages starting at proof[SOL_LOG_DATA_OFFSET]
+        uint256 offset = SOL_LOG_DATA_OFFSET;
         for (uint256 i = 0; i < logMessages_.length; i++) {
             bytes memory logBytes = bytes(logMessages_[i]);
             uint256 logEnd = offset + 2 + logBytes.length;
-            require(logEnd <= type(uint16).max, "Log message end exceeds uint16 range");
+            if (logEnd > type(uint16).max) revert LogMessageEndExceedsUint16();
 
             // Write 2-byte length prefix (big endian)
             bytes2 logEndBytes = bytes2(uint16(logEnd));

--- a/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
+++ b/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
@@ -18,8 +18,8 @@
 pragma solidity ^0.8.15;
 
 import { Base64 } from "openzeppelin/utils/Base64.sol";
-import { Strings } from "openzeppelin/utils/Strings.sol";
 
+import { Base58 } from "../../Base58.sol";
 import { CrossL2ProverV2 } from "../core/prove_api/CrossL2ProverV2.sol";
 
 contract MockCrossL2ProverV2 is CrossL2ProverV2 {
@@ -267,12 +267,12 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
      * @dev Formats a Solana log line in the shape `validateSolLogs` returns: a human-readable string of the form
      *      `"program: <base58 program id>, <base64 blob>"` (the on-chain `"Prove: "` prefix is already stripped).
      *
-     *      SIMPLIFICATION: real Polymer renders the program id in base58; this mock renders it in HEX instead. On-chain
-     *      base58 encoding is impractical (no cheap library) and the rendered program id is purely cosmetic here — the
-     *      oracle never parses it, extracting only the trailing base64 blob after the first `", "` delimiter (and hex,
-     *      like base58, contains no `", "`). True base58 fidelity is pinned separately by the immutable
-     *      `test_receiveSolanaMessage_golden_fixture` tests, which hardcode a real base58 program id in the log line.
-     *      The trailing base64 blob is what the oracle actually decodes.
+     *      The program id is rendered in base58 of the embedded bytes32 program id, matching both real Polymer output
+     *      and the oracle's enforced binding (the oracle requires the log to begin with exactly
+     *      `"program: " + base58(returnedProgramId) + ", "`). This keeps the mock producer consistent with the
+     *      consumer: passing `programId == returnedProgramId` yields a log the oracle accepts, while a mismatching id
+     *      produces a log the oracle rejects with `SolanaProgramIdMismatch`. The same base58 encoder used by the
+     *      oracle ({Base58}) is reused here so both sides agree byte-for-byte.
      * @param programId Solana program id embedded in the human-readable prefix.
      * @param blob Raw bytes to be base64-encoded as the log payload.
      * @return The formatted log string.
@@ -281,9 +281,7 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
         bytes32 programId,
         bytes memory blob
     ) public pure returns (string memory) {
-        return string(
-            abi.encodePacked("program: ", Strings.toHexString(uint256(programId), 32), ", ", Base64.encode(blob))
-        );
+        return string(abi.encodePacked("program: ", Base58.encode(programId), ", ", Base64.encode(blob)));
     }
 
     /**

--- a/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
+++ b/src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol
@@ -17,6 +17,9 @@
 
 pragma solidity ^0.8.15;
 
+import { Base64 } from "openzeppelin/utils/Base64.sol";
+import { Strings } from "openzeppelin/utils/Strings.sol";
+
 import { CrossL2ProverV2 } from "../core/prove_api/CrossL2ProverV2.sol";
 
 contract MockCrossL2ProverV2 is CrossL2ProverV2 {
@@ -112,6 +115,57 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
     }
 
     /**
+     * @dev Modified validateSolLogs for testing. Skips signature and membership verification
+     * to focus on proof structure and log message parsing.
+     */
+    function validateSolLogs(
+        bytes calldata proof
+    ) external pure override returns (uint32 chainId, bytes32 programID, string[] memory logMessages) {
+        // Extract chainId from proof[97:101]
+        chainId = uint32(bytes4(proof[97:101]));
+
+        // Skip sequencer signature verification (normally done with _verifySequencerSignature)
+        // In production, this ensures the proof is signed by the sequencer, but for testing,
+        // we assume a valid signature.
+
+        // Extract programID from proof[182:214]
+        programID = bytes32(proof[182:214]);
+
+        // Extract number of log messages from proof[117]
+        uint8 numLogMessages = uint8(proof[117]);
+        logMessages = new string[](numLogMessages);
+
+        // Parse log messages
+        //
+        // Layout in `proof` starting at byte 214 (after header, signature, chainId, heights, txSignature, programID):
+        //   For each log i:
+        //     - 2 bytes: big-endian end offset of this log within the proof buffer (absolute index, not length)
+        //     - N bytes: UTF-8 bytes of the log string itself
+        //
+        // So the first log looks like:
+        //   [ log0_end (2 bytes) ][ log0_bytes ... up to log0_end-1 ]
+        // The second log immediately follows, starting at log0_end, with its own 2-byte end offset, etc.
+        uint256 currLogMessageStart = 214;
+        uint256 currentLogMessageEnd = 214; // Initialised for the 0-log edge case
+
+        for (uint256 i = 0; i < logMessages.length; ++i) {
+            // Read the absolute end offset of this log's bytes
+            currentLogMessageEnd = uint16(bytes2(proof[currLogMessageStart:currLogMessageStart + 2]));
+            require(currentLogMessageEnd <= proof.length, "Log message end exceeds proof length");
+
+            // Slice out the log string bytes (skip the 2-byte end offset)
+            logMessages[i] = string(proof[currLogMessageStart + 2:currentLogMessageEnd]);
+
+            // Next log starts where this one ends
+            currLogMessageStart = currentLogMessageEnd;
+        }
+
+        // Skip IAVL proof verification (normally done with verifyMembership)
+        // In production, this checks the log's inclusion in the state root, but for testing,
+        // we assume membership is valid.
+    }
+
+    /**
      * @dev Helper function to generate a mock proof for testing.
      * @param chainId_ Source chain ID.
      * @param numTopics Number of topics in the event.
@@ -182,6 +236,129 @@ contract MockCrossL2ProverV2 is CrossL2ProverV2 {
 
         // iavlProof (dummy, 32 bytes)
         for (uint256 i = eventEnd; i < proof.length; i++) {
+            proof[i] = bytes1(0);
+        }
+
+        return proof;
+    }
+
+    /**
+     * @dev Formats a Solana log line exactly as `validateSolLogs` returns it: a human-readable string of the form
+     *      `"program: <base58 program id>, <base64 blob>"` (the on-chain `"Prove: "` prefix is already stripped).
+     *      The base58 program id is stand-in-encoded here as hex, which is sufficient for exercising the parser (it
+     *      contains no `", "` delimiter). The trailing base64 blob is what the oracle actually decodes.
+     * @param programId Solana program id embedded in the human-readable prefix.
+     * @param blob Raw bytes to be base64-encoded as the log payload.
+     * @return The formatted log string.
+     */
+    function formatSolLogMessage(
+        bytes32 programId,
+        bytes memory blob
+    ) public pure returns (string memory) {
+        return string(
+            abi.encodePacked("program: ", Strings.toHexString(uint256(programId), 32), ", ", Base64.encode(blob))
+        );
+    }
+
+    /**
+     * @dev Generates a mock Solana proof and emits it for local testing.
+     * @param chainId_ Source chain ID (should be 2 for Solana).
+     * @param programID Solana program ID that emitted the logs.
+     * @param logMessages Array of log message strings.
+     * @return Mock proof bytes.
+     */
+    function generateAndEmitSolProof(
+        uint32 chainId_,
+        bytes32 programID,
+        string[] memory logMessages
+    ) external returns (bytes memory) {
+        require(logMessages.length > 0, "At least one log message required");
+
+        bytes memory proof = generateMockSolProof(chainId_, programID, logMessages);
+
+        emit ProofGenerated(proof);
+        return proof;
+    }
+
+    /**
+     * @dev Helper function to generate a mock Solana proof for testing.
+     * @param chainId_ Source chain ID (should be 2 for Solana).
+     * @param programID Solana program ID that emitted the logs.
+     * @param logMessages_ Array of log message strings.
+     * @return Mock proof bytes.
+     */
+    function generateMockSolProof(
+        uint32 chainId_,
+        bytes32 programID,
+        string[] memory logMessages_
+    ) public pure returns (bytes memory) {
+        require(logMessages_.length > 0, "At least one log message required");
+        require(logMessages_.length <= 255, "Too many log messages");
+
+        // Calculate total length of all log messages
+        uint256 totalLogLength = 0;
+        for (uint256 i = 0; i < logMessages_.length; i++) {
+            totalLogLength += bytes(logMessages_[i]).length + 2; // +2 for the 2-byte length prefix
+        }
+
+        // Calculate proof length:
+        // - Fixed header: 214 bytes (state root + signature + chainId + heights + numLogs + txSig + programID)
+        // - Log messages: totalLogLength bytes
+        // - IAVL proof: 32 bytes (dummy)
+        uint256 proofLength = 214 + totalLogLength + 32;
+
+        bytes memory proof = new bytes(proofLength);
+
+        // Leave fixed fields with dummy values (already 0)
+        // - stateRoot (32 bytes): dummy
+        // - signature (65 bytes): dummy
+
+        // Populate chainId (4 bytes) at proof[97:101]
+        bytes4 chainIdBytes = bytes4(chainId_);
+        for (uint256 i = 0; i < 4; i++) {
+            proof[97 + i] = chainIdBytes[i];
+        }
+
+        // peptideHeight (proof[101:109]) - dummy value of 100
+        proof[108] = bytes1(uint8(100));
+
+        // blockHeight (proof[109:117]) - dummy value of 200
+        proof[116] = bytes1(uint8(200));
+
+        // number of log messages (proof[117])
+        proof[117] = bytes1(uint8(logMessages_.length));
+
+        // txSignature high (proof[118:150]) - dummy value
+        // txSignature low (proof[150:182]) - dummy value
+        // (already 0)
+
+        // programID (proof[182:214])
+        for (uint256 i = 0; i < 32; i++) {
+            proof[182 + i] = programID[i];
+        }
+
+        // Encode log messages starting at proof[214]
+        uint256 offset = 214;
+        for (uint256 i = 0; i < logMessages_.length; i++) {
+            bytes memory logBytes = bytes(logMessages_[i]);
+            uint256 logEnd = offset + 2 + logBytes.length;
+            require(logEnd <= type(uint16).max, "Log message end exceeds uint16 range");
+
+            // Write 2-byte length prefix (big endian)
+            bytes2 logEndBytes = bytes2(uint16(logEnd));
+            proof[offset] = logEndBytes[0];
+            proof[offset + 1] = logEndBytes[1];
+
+            // Write log message content
+            for (uint256 j = 0; j < logBytes.length; j++) {
+                proof[offset + 2 + j] = logBytes[j];
+            }
+
+            offset = logEnd;
+        }
+
+        // IAVL proof (dummy, 32 bytes)
+        for (uint256 i = offset; i < proof.length; i++) {
             proof[i] = bytes1(0);
         }
 

--- a/test/oracle/polymer/PolymerOracle.t.sol
+++ b/test/oracle/polymer/PolymerOracle.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.22;
 
 import { Test } from "forge-std/Test.sol";
 
+import { Base64 } from "openzeppelin/utils/Base64.sol";
 import { MandateOutput } from "src/input/types/MandateOutputType.sol";
 import { PolymerOracle } from "src/integrations/oracles/polymer/PolymerOracle.sol";
 import { MockCrossL2ProverV2 } from "src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol";
@@ -498,5 +499,106 @@ contract PolymerOracleTest is Test {
         IInputSettlerEscrow(inputSettlerEscrow).finalise(order, solveParams, solver.toIdentifier(), hex"");
 
         assertEq(token.balanceOf(solver), amount);
+    }
+
+    /// ************** Solana Processing ************** ///
+
+    /// @dev Builds a Solana log in the real Polymer format: `"program: <base58>, <base64 blob>"`, where the decoded
+    ///      blob is layout (a) `application(32) || payload(dynamic)`.
+    function _encodeSolanaLog(
+        bytes32 programId,
+        bytes32 application,
+        bytes memory payload
+    ) internal view returns (string memory) {
+        return mockCrossL2ProverV2.formatSolLogMessage(programId, abi.encodePacked(application, payload));
+    }
+
+    function test_receiveSolanaMessage_with_proof() public {
+        uint32 solanaChainId = 2; // base variant uses identity chain mapping.
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+        bytes32 payloadHash = keccak256(payload);
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(programID, application, payload);
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        // Sender identity is the authenticated program id.
+        vm.expectEmit();
+        emit OutputProven(uint256(solanaChainId), programID, application, payloadHash);
+        polymerOracle.receiveSolanaMessage(mockProof);
+
+        assertTrue(polymerOracle.isProven(uint256(solanaChainId), programID, application, payloadHash));
+    }
+
+    /// @dev CRITICAL regression on the base variant: an attacker program's forged log lands under the attacker's own
+    ///      program id and cannot forge an attestation for a victim's trusted oracle identity.
+    function test_receiveSolanaMessage_forged_program_self_namespaces() public {
+        uint32 solanaChainId = 2;
+        bytes32 victimProgramID = keccak256("victim-solana-program");
+        bytes32 attackerProgramID = keccak256("attacker-solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("release-funds");
+        bytes32 payloadHash = keccak256(payload);
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+
+        bytes memory mockProof =
+            mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, attackerProgramID, logMessages);
+
+        vm.expectEmit();
+        emit OutputProven(uint256(solanaChainId), attackerProgramID, application, payloadHash);
+        polymerOracle.receiveSolanaMessage(mockProof);
+
+        assertFalse(polymerOracle.isProven(uint256(solanaChainId), victimProgramID, application, payloadHash));
+        assertTrue(polymerOracle.isProven(uint256(solanaChainId), attackerProgramID, application, payloadHash));
+    }
+
+    function test_receiveSolanaMessage_wrong_chain_id_reverts() public {
+        uint32 wrongChainId = 1; // Not Solana (should be 2)
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(programID, application, payload);
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(wrongChainId, programID, logMessages);
+
+        vm.expectRevert(PolymerOracle.NotSolanaMessage.selector);
+        polymerOracle.receiveSolanaMessage(mockProof);
+    }
+
+    function test_receiveSolanaMessage_malformed_log_missing_delimiter_reverts() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+
+        // Raw base64 blob with no `"program: ..., "` wrapper: no `", "` delimiter.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = Base64.encode(abi.encodePacked(application, payload));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        vm.expectRevert(PolymerOracle.MalformedSolanaLog.selector);
+        polymerOracle.receiveSolanaMessage(mockProof);
+    }
+
+    function test_receiveSolanaMessage_invalid_solana_message_reverts() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+
+        // Decoded blob shorter than the required application(32) field.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = mockCrossL2ProverV2.formatSolLogMessage(programID, abi.encodePacked(bytes4(0xdeadbeef)));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        vm.expectRevert(PolymerOracle.InvalidSolanaMessage.selector);
+        polymerOracle.receiveSolanaMessage(mockProof);
     }
 }

--- a/test/oracle/polymer/PolymerOracle.t.sol
+++ b/test/oracle/polymer/PolymerOracle.t.sol
@@ -504,7 +504,7 @@ contract PolymerOracleTest is Test {
     /// ************** Solana Processing ************** ///
 
     /// @dev Builds a Solana log in the real Polymer format: `"program: <base58>, <base64 blob>"`, where the decoded
-    ///      blob is layout (a) `application(32) || payload(dynamic)`.
+    ///      blob is layout `application(32) || payload(dynamic)`.
     function _encodeSolanaLog(
         bytes32 programId,
         bytes32 application,
@@ -526,6 +526,44 @@ contract PolymerOracleTest is Test {
         bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
 
         // Sender identity is the authenticated program id.
+        vm.expectEmit();
+        emit OutputProven(uint256(solanaChainId), programID, application, payloadHash);
+        polymerOracle.receiveSolanaMessage(mockProof);
+
+        assertTrue(polymerOracle.isProven(uint256(solanaChainId), programID, application, payloadHash));
+    }
+
+    /// @dev GOLDEN fixture. The log line, program id, application and payload hash below are immutable literals
+    ///      computed OFFLINE from the documented wire format `"program: <base58 program id>, <base64(source(32) ||
+    ///      payload)>"` — deliberately independent of the mock's `formatSolLogMessage` (which renders the program id
+    ///      as hex). This pins the exact bytes the shipped oracle must accept and the attestation slot it must set for
+    ///      the Polymer-authenticated program id.
+    ///
+    ///      Fixture (base58 program id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"):
+    ///      - programID (bytes32)   = 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9
+    ///      - application (bytes32) = 0x...deadbeef
+    ///      - payload               = "golden-payload"
+    ///      - base64(application(32) || payload) = "AAAA...N6tvu9nb2xkZW4tcGF5bG9hZA=="
+    ///      - payloadHash = keccak256("golden-payload")
+    function test_receiveSolanaMessage_golden_fixture() public {
+        uint32 solanaChainId = 2;
+
+        // Program id authenticated by Polymer (proof[182:214]); the base58 rendering in the log line below is
+        // "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", which base58-decodes to exactly these 32 bytes.
+        bytes32 programID = 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9;
+        bytes32 application = 0x00000000000000000000000000000000000000000000000000000000deadbeef;
+        // keccak256("golden-payload")
+        bytes32 payloadHash = 0x11d41300e405124d7e79e9a507b5abe013e238cf350fbf90a46fcca903614473;
+
+        // Hand-built log line in the exact form `validateSolLogs` returns. The trailing token is
+        // base64(application(32) || "golden-payload"); everything before ", " is the (cosmetic) program-id prefix the
+        // oracle never parses.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] =
+            "program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN6tvu9nb2xkZW4tcGF5bG9hZA==";
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
         vm.expectEmit();
         emit OutputProven(uint256(solanaChainId), programID, application, payloadHash);
         polymerOracle.receiveSolanaMessage(mockProof);

--- a/test/oracle/polymer/PolymerOracle.t.sol
+++ b/test/oracle/polymer/PolymerOracle.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/Test.sol";
 
 import { Base64 } from "openzeppelin/utils/Base64.sol";
 import { MandateOutput } from "src/input/types/MandateOutputType.sol";
+import { Base58 } from "src/integrations/oracles/polymer/Base58.sol";
 import { PolymerOracle } from "src/integrations/oracles/polymer/PolymerOracle.sol";
 import { MockCrossL2ProverV2 } from "src/integrations/oracles/polymer/external/mocks/MockCrossL2ProverV2.sol";
 import { LibAddress } from "src/libs/LibAddress.sol";
@@ -535,9 +536,9 @@ contract PolymerOracleTest is Test {
 
     /// @dev GOLDEN fixture. The log line, program id, application and payload hash below are immutable literals
     ///      computed OFFLINE from the documented wire format `"program: <base58 program id>, <base64(source(32) ||
-    ///      payload)>"` — deliberately independent of the mock's `formatSolLogMessage` (which renders the program id
-    ///      as hex). This pins the exact bytes the shipped oracle must accept and the attestation slot it must set for
-    ///      the Polymer-authenticated program id.
+    ///      payload)>"`. This pins the exact bytes the shipped oracle must accept and the attestation slot it must set
+    ///      for the Polymer-authenticated program id, and cross-checks the on-chain {Base58} encoder: the oracle only
+    ///      accepts this log if `base58(programID)` equals the hand-written "TokenkegQ..." base58 rendering.
     ///
     ///      Fixture (base58 program id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"):
     ///      - programID (bytes32)   = 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9
@@ -556,8 +557,8 @@ contract PolymerOracleTest is Test {
         bytes32 payloadHash = 0x11d41300e405124d7e79e9a507b5abe013e238cf350fbf90a46fcca903614473;
 
         // Hand-built log line in the exact form `validateSolLogs` returns. The trailing token is
-        // base64(application(32) || "golden-payload"); everything before ", " is the (cosmetic) program-id prefix the
-        // oracle never parses.
+        // base64(application(32) || "golden-payload"); the prefix "program: TokenkegQ..., " must equal
+        // "program: " + base58(programID) + ", " or the oracle rejects it with SolanaProgramIdMismatch.
         string[] memory logMessages = new string[](1);
         logMessages[0] =
             "program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN6tvu9nb2xkZW4tcGF5bG9hZA==";
@@ -571,8 +572,9 @@ contract PolymerOracleTest is Test {
         assertTrue(polymerOracle.isProven(uint256(solanaChainId), programID, application, payloadHash));
     }
 
-    /// @dev CRITICAL regression on the base variant: an attacker program's forged log lands under the attacker's own
-    ///      program id and cannot forge an attestation for a victim's trusted oracle identity.
+    /// @dev CRITICAL regression on the base variant: with the enforced program-id binding an attacker can only name
+    ///      (and be authenticated as) their OWN program id in the log, so their forged attestation lands under the
+    ///      attacker's own program id and is invisible to any honest order that references the real (victim) program.
     function test_receiveSolanaMessage_forged_program_self_namespaces() public {
         uint32 solanaChainId = 2;
         bytes32 victimProgramID = keccak256("victim-solana-program");
@@ -581,8 +583,10 @@ contract PolymerOracleTest is Test {
         bytes memory payload = bytes("release-funds");
         bytes32 payloadHash = keccak256(payload);
 
+        // The attacker can only produce a log naming their own program (the binding requires the in-log id to equal
+        // the Polymer-authenticated program id).
         string[] memory logMessages = new string[](1);
-        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+        logMessages[0] = _encodeSolanaLog(attackerProgramID, application, payload);
 
         bytes memory mockProof =
             mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, attackerProgramID, logMessages);
@@ -593,6 +597,31 @@ contract PolymerOracleTest is Test {
 
         assertFalse(polymerOracle.isProven(uint256(solanaChainId), victimProgramID, application, payloadHash));
         assertTrue(polymerOracle.isProven(uint256(solanaChainId), attackerProgramID, application, payloadHash));
+    }
+
+    /// @dev CRITICAL regression for Finding 1: a log whose embedded program id does NOT equal the Polymer-authenticated
+    ///      `returnedProgramId` MUST revert. Tested in both directions (victim-returned/attacker-in-log and vice
+    ///      versa) so a mismatching (returnedProgramId, in-log id) pair can never slip through.
+    function test_receiveSolanaMessage_program_id_mismatch_reverts() public {
+        uint32 solanaChainId = 2;
+        bytes32 victimProgramID = keccak256("victim-solana-program");
+        bytes32 attackerProgramID = keccak256("attacker-solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("release-funds");
+
+        // Direction 1: authenticated as victim, but the log names the attacker's program.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(attackerProgramID, application, payload);
+        bytes memory proof1 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, victimProgramID, logMessages);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
+        polymerOracle.receiveSolanaMessage(proof1);
+
+        // Direction 2: authenticated as attacker, but the log names the victim's program.
+        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+        bytes memory proof2 =
+            mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, attackerProgramID, logMessages);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
+        polymerOracle.receiveSolanaMessage(proof2);
     }
 
     function test_receiveSolanaMessage_wrong_chain_id_reverts() public {
@@ -610,19 +639,19 @@ contract PolymerOracleTest is Test {
         polymerOracle.receiveSolanaMessage(mockProof);
     }
 
-    function test_receiveSolanaMessage_malformed_log_missing_delimiter_reverts() public {
+    function test_receiveSolanaMessage_malformed_log_missing_prefix_reverts() public {
         uint32 solanaChainId = 2;
         bytes32 programID = keccak256("solana-program");
         bytes32 application = makeAddr("settler").toIdentifier();
         bytes memory payload = bytes("test-payload");
 
-        // Raw base64 blob with no `"program: ..., "` wrapper: no `", "` delimiter.
+        // Raw base64 blob with no `"program: <base58>, "` wrapper: the authenticated prefix is absent.
         string[] memory logMessages = new string[](1);
         logMessages[0] = Base64.encode(abi.encodePacked(application, payload));
 
         bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
 
-        vm.expectRevert(PolymerOracle.MalformedSolanaLog.selector);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
         polymerOracle.receiveSolanaMessage(mockProof);
     }
 
@@ -638,5 +667,37 @@ contract PolymerOracleTest is Test {
 
         vm.expectRevert(PolymerOracle.InvalidSolanaMessage.selector);
         polymerOracle.receiveSolanaMessage(mockProof);
+    }
+
+    /// @dev Finding 3: a 32-byte blob decodes to `application(32)` with an EMPTY payload; it must be rejected rather
+    ///      than attesting over keccak256("").
+    function test_receiveSolanaMessage_empty_payload_reverts() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+
+        // Exactly 32 bytes: application field only, no payload.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = mockCrossL2ProverV2.formatSolLogMessage(programID, abi.encodePacked(application));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        vm.expectRevert(PolymerOracle.InvalidSolanaMessage.selector);
+        polymerOracle.receiveSolanaMessage(mockProof);
+    }
+
+    /// @dev Unit test for the on-chain {Base58} encoder against the known golden program-id vector: the bytes32
+    ///      0x06ddf6...eff00a9 MUST base58-encode to "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" (the same value the
+    ///      golden-fixture log line hard-codes and the oracle's binding depends on).
+    function test_base58_encode_golden_program_id() public pure {
+        bytes32 programID = 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9;
+        assertEq(Base58.encode(programID), "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    }
+
+    /// @dev Base58 leading-zero rule: each leading 0x00 byte maps to one leading '1'.
+    function test_base58_encode_leading_zeros() public pure {
+        assertEq(Base58.encode(bytes32(0)), "11111111111111111111111111111111");
+        // 0x00...0001 -> 31 leading '1' + '2' (value 1 is the second alphabet symbol).
+        assertEq(Base58.encode(bytes32(uint256(1))), "11111111111111111111111111111112");
     }
 }

--- a/test/oracle/polymer/PolymerOracleMapped.t.sol
+++ b/test/oracle/polymer/PolymerOracleMapped.t.sol
@@ -534,8 +534,9 @@ contract PolymerOracleMappedTest is Test {
     }
 
     /// @dev CRITICAL regression: a proof from an attacker-deployed program cannot forge an attestation for a victim's
-    ///      trusted oracle. Because the sender identity is `returnedProgramId` (authenticated), the forged attestation
-    ///      lands in the attacker's own slot and is invisible to any honest order that references the real program id.
+    ///      trusted oracle. With the enforced program-id binding the attacker can only name (and be authenticated as)
+    ///      their own program in the log, so the forged attestation lands in the attacker's own slot and is invisible
+    ///      to any honest order that references the real program id.
     function test_receiveSolanaMessage_forged_program_self_namespaces() public {
         uint32 solanaChainId = 2;
         bytes32 victimProgramID = keccak256("victim-solana-program");
@@ -545,9 +546,9 @@ contract PolymerOracleMappedTest is Test {
         bytes memory payload = bytes("release-funds");
         bytes32 payloadHash = keccak256(payload);
 
-        // Attacker emits a log via their own program; the in-log content is irrelevant to identity.
+        // The attacker can only produce a log naming their own program (the in-log id must equal the authenticated id).
         string[] memory logMessages = new string[](1);
-        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+        logMessages[0] = _encodeSolanaLog(attackerProgramID, application, payload);
 
         // The prover authenticates the emitting program as the attacker's program.
         bytes memory mockProof =
@@ -568,13 +569,41 @@ contract PolymerOracleMappedTest is Test {
         assertTrue(polymerOracleMapped.isProven(remoteChainId, attackerProgramID, application, payloadHash));
     }
 
-    function test_receiveSolanaMessage_malformed_log_missing_delimiter_reverts() public {
+    /// @dev CRITICAL regression for Finding 1 (mapped variant): a log whose embedded program id does NOT equal the
+    ///      Polymer-authenticated `returnedProgramId` MUST revert. Tested in both directions.
+    function test_receiveSolanaMessage_program_id_mismatch_reverts_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 victimProgramID = keccak256("victim-solana-program");
+        bytes32 attackerProgramID = keccak256("attacker-solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("release-funds");
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        // Direction 1: authenticated as victim, but the log names the attacker's program.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(attackerProgramID, application, payload);
+        bytes memory proof1 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, victimProgramID, logMessages);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
+        polymerOracleMapped.receiveSolanaMessage(proof1);
+
+        // Direction 2: authenticated as attacker, but the log names the victim's program.
+        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+        bytes memory proof2 =
+            mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, attackerProgramID, logMessages);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
+        polymerOracleMapped.receiveSolanaMessage(proof2);
+    }
+
+    function test_receiveSolanaMessage_malformed_log_missing_prefix_reverts() public {
         uint32 solanaChainId = 2;
         bytes32 programID = keccak256("solana-program");
         bytes32 application = makeAddr("settler").toIdentifier();
         bytes memory payload = bytes("test-payload");
 
-        // A raw base64 blob with no `"program: ..., "` wrapper: no `", "` delimiter to split on.
+        // A raw base64 blob with no `"program: <base58>, "` wrapper: the authenticated prefix is absent.
         string[] memory logMessages = new string[](1);
         logMessages[0] = Base64.encode(abi.encodePacked(application, payload));
 
@@ -584,7 +613,26 @@ contract PolymerOracleMappedTest is Test {
         vm.prank(owner);
         polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
 
-        vm.expectRevert(PolymerOracle.MalformedSolanaLog.selector);
+        vm.expectRevert(PolymerOracle.SolanaProgramIdMismatch.selector);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+    }
+
+    /// @dev Finding 3 (mapped variant): a 32-byte blob (application only, empty payload) must be rejected.
+    function test_receiveSolanaMessage_empty_payload_reverts_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = mockCrossL2ProverV2.formatSolLogMessage(programID, abi.encodePacked(application));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectRevert(PolymerOracle.InvalidSolanaMessage.selector);
         polymerOracleMapped.receiveSolanaMessage(mockProof);
     }
 

--- a/test/oracle/polymer/PolymerOracleMapped.t.sol
+++ b/test/oracle/polymer/PolymerOracleMapped.t.sol
@@ -344,7 +344,7 @@ contract PolymerOracleMappedTest is Test {
     ///
     ///      `validateSolLogs` returns each log as a human-readable string of the form
     ///      `"program: <base58 program id>, <base64 blob>"`. The oracle extracts the trailing base64 blob and decodes
-    ///      it under layout (a): `application (32) || payload (dynamic)`. The sender identity is taken from the
+    ///      it under layout: `application (32) || payload (dynamic)`. The sender identity is taken from the
     ///      prover-authenticated `programID` (NOT from log content); the oracle attests over
     ///      `payloadHash = keccak256(payload)` and stores it under
     ///      `_attestations[remoteChainId][programID][application][payloadHash] = true`.
@@ -375,6 +375,35 @@ contract PolymerOracleMappedTest is Test {
         polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
 
         // Sender identity is the authenticated program id.
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application, payloadHash);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+
+        assertTrue(polymerOracleMapped.isProven(remoteChainId, programID, application, payloadHash));
+    }
+
+    /// @dev GOLDEN fixture (mapped variant). Immutable literals computed OFFLINE from the documented wire format
+    ///      `"program: <base58 program id>, <base64(source(32) || payload)>"`, independent of the mock's
+    ///      `formatSolLogMessage`. Pins the exact bytes the shipped oracle must accept and the attestation slot it
+    ///      must set for the Polymer-authenticated program id. See PolymerOracle.t.sol for the fixture derivation.
+    function test_receiveSolanaMessage_golden_fixture_mapped() public {
+        uint32 solanaChainId = 2;
+
+        bytes32 programID = 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9;
+        bytes32 application = 0x00000000000000000000000000000000000000000000000000000000deadbeef;
+        // keccak256("golden-payload")
+        bytes32 payloadHash = 0x11d41300e405124d7e79e9a507b5abe013e238cf350fbf90a46fcca903614473;
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] =
+            "program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN6tvu9nb2xkZW4tcGF5bG9hZA==";
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
         vm.expectEmit();
         emit OutputProven(remoteChainId, programID, application, payloadHash);
         polymerOracleMapped.receiveSolanaMessage(mockProof);

--- a/test/oracle/polymer/PolymerOracleMapped.t.sol
+++ b/test/oracle/polymer/PolymerOracleMapped.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.22;
 
 import { Test } from "forge-std/Test.sol";
 
+import { Base64 } from "openzeppelin/utils/Base64.sol";
 import { MandateOutput } from "src/input/types/MandateOutputType.sol";
 import { PolymerOracle } from "src/integrations/oracles/polymer/PolymerOracle.sol";
 import { PolymerOracleMapped } from "src/integrations/oracles/polymer/PolymerOracleMapped.sol";
@@ -336,5 +337,243 @@ contract PolymerOracleMappedTest is Test {
                 expectedPayloadHash
             )
         );
+    }
+
+    /// @dev Helper to build a single Solana log entry in the real Polymer format consumed by `PolymerOracle`'s
+    ///      Solana path (`receiveSolanaMessage`).
+    ///
+    ///      `validateSolLogs` returns each log as a human-readable string of the form
+    ///      `"program: <base58 program id>, <base64 blob>"`. The oracle extracts the trailing base64 blob and decodes
+    ///      it under layout (a): `application (32) || payload (dynamic)`. The sender identity is taken from the
+    ///      prover-authenticated `programID` (NOT from log content); the oracle attests over
+    ///      `payloadHash = keccak256(payload)` and stores it under
+    ///      `_attestations[remoteChainId][programID][application][payloadHash] = true`.
+    function _encodeSolanaLog(
+        bytes32 programId,
+        bytes32 application,
+        bytes memory payload
+    ) internal view returns (string memory) {
+        bytes memory blob = abi.encodePacked(application, payload);
+        return mockCrossL2ProverV2.formatSolLogMessage(programId, blob);
+    }
+
+    function test_receiveSolanaMessage_with_proof_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+        bytes32 payloadHash = keccak256(payload);
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(programID, application, payload);
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        // Sender identity is the authenticated program id.
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application, payloadHash);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+
+        assertTrue(polymerOracleMapped.isProven(remoteChainId, programID, application, payloadHash));
+    }
+
+    function test_receiveSolanaMessage_multiple_logs_single_proof_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+
+        bytes32 application1 = makeAddr("settler1").toIdentifier();
+        bytes memory payload1 = bytes("test-payload-1");
+        bytes32 payloadHash1 = keccak256(payload1);
+
+        bytes32 application2 = makeAddr("settler2").toIdentifier();
+        bytes memory payload2 = bytes("test-payload-2");
+        bytes32 payloadHash2 = keccak256(payload2);
+
+        // Two logs within a SINGLE proof.
+        string[] memory logMessages = new string[](2);
+        logMessages[0] = _encodeSolanaLog(programID, application1, payload1);
+        logMessages[1] = _encodeSolanaLog(programID, application2, payload2);
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application1, payloadHash1);
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application2, payloadHash2);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+
+        assertTrue(polymerOracleMapped.isProven(remoteChainId, programID, application1, payloadHash1));
+        assertTrue(polymerOracleMapped.isProven(remoteChainId, programID, application2, payloadHash2));
+    }
+
+    function test_receiveSolanaMessage_multiple_proofs_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+
+        bytes32 application1 = makeAddr("settler1").toIdentifier();
+        bytes memory payload1 = bytes("test-payload-1");
+        bytes32 payloadHash1 = keccak256(payload1);
+
+        bytes32 application2 = makeAddr("settler2").toIdentifier();
+        bytes memory payload2 = bytes("test-payload-2");
+        bytes32 payloadHash2 = keccak256(payload2);
+
+        string[] memory logMessages1 = new string[](1);
+        logMessages1[0] = _encodeSolanaLog(programID, application1, payload1);
+
+        string[] memory logMessages2 = new string[](1);
+        logMessages2[0] = _encodeSolanaLog(programID, application2, payload2);
+
+        bytes memory mockProof1 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages1);
+        bytes memory mockProof2 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages2);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application1, payloadHash1);
+        polymerOracleMapped.receiveSolanaMessage(mockProof1);
+
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application2, payloadHash2);
+        polymerOracleMapped.receiveSolanaMessage(mockProof2);
+    }
+
+    function test_receiveSolanaMessage_multiple_proofs_batch_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+
+        bytes32 application1 = makeAddr("settler1").toIdentifier();
+        bytes memory payload1 = bytes("test-payload-1");
+        bytes32 payloadHash1 = keccak256(payload1);
+
+        bytes32 application2 = makeAddr("settler2").toIdentifier();
+        bytes memory payload2 = bytes("test-payload-2");
+        bytes32 payloadHash2 = keccak256(payload2);
+
+        string[] memory logMessages1 = new string[](1);
+        logMessages1[0] = _encodeSolanaLog(programID, application1, payload1);
+
+        string[] memory logMessages2 = new string[](1);
+        logMessages2[0] = _encodeSolanaLog(programID, application2, payload2);
+
+        bytes memory mockProof1 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages1);
+        bytes memory mockProof2 = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages2);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application1, payloadHash1);
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, programID, application2, payloadHash2);
+
+        bytes[] memory proofs = new bytes[](2);
+        proofs[0] = mockProof1;
+        proofs[1] = mockProof2;
+
+        polymerOracleMapped.receiveSolanaMessage(proofs);
+    }
+
+    function test_receiveSolanaMessage_wrong_chain_id_mapped_reverts() public {
+        uint32 wrongChainId = 1; // Not Solana (should be 2)
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(programID, application, payload);
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(wrongChainId, programID, logMessages);
+
+        // Should revert on chainId check before mapping is even consulted.
+        vm.expectRevert(PolymerOracle.NotSolanaMessage.selector);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+    }
+
+    /// @dev CRITICAL regression: a proof from an attacker-deployed program cannot forge an attestation for a victim's
+    ///      trusted oracle. Because the sender identity is `returnedProgramId` (authenticated), the forged attestation
+    ///      lands in the attacker's own slot and is invisible to any honest order that references the real program id.
+    function test_receiveSolanaMessage_forged_program_self_namespaces() public {
+        uint32 solanaChainId = 2;
+        bytes32 victimProgramID = keccak256("victim-solana-program");
+        bytes32 attackerProgramID = keccak256("attacker-solana-program");
+
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("release-funds");
+        bytes32 payloadHash = keccak256(payload);
+
+        // Attacker emits a log via their own program; the in-log content is irrelevant to identity.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = _encodeSolanaLog(victimProgramID, application, payload);
+
+        // The prover authenticates the emitting program as the attacker's program.
+        bytes memory mockProof =
+            mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, attackerProgramID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        // Attestation is written under the ATTACKER's program id, and emitted as such.
+        vm.expectEmit();
+        emit OutputProven(remoteChainId, attackerProgramID, application, payloadHash);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+
+        // The slot an honest order would read (keyed by the victim program id) is NOT proven.
+        assertFalse(polymerOracleMapped.isProven(remoteChainId, victimProgramID, application, payloadHash));
+        // The attestation only exists under the attacker's own namespace.
+        assertTrue(polymerOracleMapped.isProven(remoteChainId, attackerProgramID, application, payloadHash));
+    }
+
+    function test_receiveSolanaMessage_malformed_log_missing_delimiter_reverts() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+        bytes32 application = makeAddr("settler").toIdentifier();
+        bytes memory payload = bytes("test-payload");
+
+        // A raw base64 blob with no `"program: ..., "` wrapper: no `", "` delimiter to split on.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = Base64.encode(abi.encodePacked(application, payload));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectRevert(PolymerOracle.MalformedSolanaLog.selector);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
+    }
+
+    function test_receiveSolanaMessage_invalid_solana_message_reverts_mapped() public {
+        uint32 solanaChainId = 2;
+        bytes32 programID = keccak256("solana-program");
+
+        // Decoded blob shorter than the required application(32) field.
+        string[] memory logMessages = new string[](1);
+        logMessages[0] = mockCrossL2ProverV2.formatSolLogMessage(programID, abi.encodePacked(bytes4(0xdeadbeef)));
+
+        bytes memory mockProof = mockCrossL2ProverV2.generateAndEmitSolProof(solanaChainId, programID, logMessages);
+
+        uint256 remoteChainId = uint256(solanaChainId);
+        vm.prank(owner);
+        polymerOracleMapped.setChainMap(remoteChainId, remoteChainId);
+
+        vm.expectRevert(PolymerOracle.InvalidSolanaMessage.selector);
+        polymerOracleMapped.receiveSolanaMessage(mockProof);
     }
 }


### PR DESCRIPTION
## Summary

Adds a Solana → EVM proof path to `PolymerOracle` — Linear [API-699: Provable Non-Fill Refunds](https://linear.app/lifi-linear/issue/API-699/provable-non-fill-refunds).

New `receiveSolanaMessage`, backed by `ICrossL2ProverV2.validateSolLogs`, lets fills and non-fills executed on Solana be attested on EVM via Polymer, so the non-fill refund flow (and regular fill finalisation) works for Solana output chains.

## Trust model

- The remote-oracle identity is taken from Polymer's **authenticated `returnedProgramId`**, never from log content. Attestations self-namespace under the emitting program id; honest orders set `output.oracle` to the trusted Solana program id.
- Each log must begin with exactly `"program: " + base58(returnedProgramId) + ", "`, enforced via a new on-chain `Base58` encoder; any mismatch reverts `SolanaProgramIdMismatch`. The prefix is computed once per proof (invariant across logs), so multi-log proofs stay within gas limits.
- Only the trailing base64 field of the `"program: <id>, <blob>"` log is decoded; blob layout is `application(32) || payload`. Empty payloads (blob ≤ 32 bytes) are rejected rather than attesting over `keccak256("")`.

## Deployment coupling

Requires the paired `catalyst-intent-svm` change (submit emits `source || payload`, oracle identified by program id) to be deployed together.

## Testing

Golden-fixture cases for `receiveSolanaMessage` on both the base and mapped oracles, program-id-mismatch reverts in both directions, empty-payload revert, Base58 encoder unit tests (golden vectors + leading-zero rule), and an extended `MockCrossL2ProverV2` that renders the log prefix in base58 to match the enforced check. A captured real Polymer proof fixture remains a follow-up.

## Stacked PRs

This is PR 2 of 2, stacked on #126 (`feature/api-699-provable-non-fill-refunds`). It will retarget to `main` automatically when #126 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
