### PR TITLE
docs: document `fill()`'s caller-supplied `fillDeadline` parameter

### DIFF
--- a/src/output/OutputSettlerBase.sol
+++ b/src/output/OutputSettlerBase.sol
@@ -229,6 +229,9 @@ abstract contract OutputSettlerBase is IAttester, BaseInputOracle {
      * and scenarios where multiple parties might attempt to fill the same output.
      * @param orderId The unique identifier of the order.
      * @param output The `MandateOutput` struct to fill.
+     * @param fillDeadline MUST equal the signed order's `fillDeadline`. This is a caller-supplied guard only. It is
+     * not validated against the order, which this contract never sees. A larger value lets a late fill SUCCEED, and
+     * `finalise` will then permanently reject the claim with `FilledTooLate`.
      * @param fillerData The solver data containing the proposed solver.
      * @return fillRecordHash The hash of the fill record.
      */
@@ -263,6 +266,9 @@ abstract contract OutputSettlerBase is IAttester, BaseInputOracle {
      * and ensures consistent solver attribution across all outputs in a multi-output order.
      * @param orderId The unique identifier of the order.
      * @param outputs Array of `MandateOutput` structs to fill
+     * @param fillDeadline MUST equal the signed order's `fillDeadline`. This is a caller-supplied guard only. It is
+     * not validated against the order, which this contract never sees. A larger value lets a late fill SUCCEED, and
+     * `finalise` will then permanently reject the claim with `FilledTooLate`.
      * @param fillerData The solver data containing the proposed solver.
      */
     function fillOrderOutputs(


### PR DESCRIPTION
## Description

`fill()` and `fillOrderOutputs()` document `orderId`, `output` and `fillerData` but not `fillDeadline`.

The parameter is caller-supplied and checked only against `block.timestamp`; it is not validated against the order, which the output settler never sees. That is clearly intentional, but the omission is costly for integrators: passing a padded value lets a late fill succeed, and `InputSettlerBase._validateFills` then rejects the claim permanently with `FilledTooLate` (the fill timestamp is bound into the proof payload hash, so it cannot be misreported). Passing the order's true deadline makes the same late fill revert cheaply instead.

Documentation only. No behaviour change. Found while integrating a solver against the contracts deployed on 2026-08-06.

## Related Issues

- Relates to #129
- Upstream PR: https://github.com/openintentsframework/oif-contracts/pull/193

## Third-Party Integration Checklist

N/A. This PR does not integrate with any external protocol: no new dependencies, no interfaces copied.

## Additional Notes

Touches only the natspec blocks of `fill()` and `fillOrderOutputs()` in `src/output/OutputSettlerBase.sol`. No logic, no ABI and no bytecode change, so gas snapshots are unaffected.
